### PR TITLE
Feature/issues #2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development do
   gem 'listen', '~> 3.0.5'
   gem 'rack-mini-profiler', require: false
   gem 'web-console', '>= 3.3.0'
+  gem 'letter_opener_web'
 end
 
 group :test do
@@ -74,3 +75,5 @@ group :test do
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem 'rexml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,6 +432,7 @@ DEPENDENCIES
   rails (= 6.0.3)
   rails-controller-testing
   redcarpet (~> 3.5.1)
+  rexml
   rspec-parameterized
   rspec-rails
   rspec-retry

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show edit update destroy]
+  before_action :set_team, only: %i[show edit update destroy assign_owner]
 
   def index
     @teams = Team.all
@@ -45,6 +45,12 @@ class TeamsController < ApplicationController
 
   def dashboard
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
+  end
+
+  def assign_owner
+    @team.update(owner_id: params[:owner_id])
+    @user = User.find(@team.owner_id)
+    redirect_to team_path, notice: 'オーナー権限が移動しました!'
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -51,6 +51,7 @@ class TeamsController < ApplicationController
     @team.update(owner_id: params[:owner_id])
     @user = User.find(@team.owner_id)
     redirect_to team_path, notice: 'オーナー権限が移動しました!'
+    AssignMailer.assign_mail(@team.owner.email).deliver
   end
 
   private

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -1,9 +1,8 @@
 class AssignMailer < ApplicationMailer
   default from: 'from@example.com'
 
-  def assign_mail(email, password)
+  def assign_mail(email)
     @email = email
-    @password = password
     mail to: @email, subject: I18n.t('views.messages.complete_registration')
   end
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -43,6 +43,9 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if current_user == assign.team.owner %>
+                        <td><%= link_to 'Transfer authority', assign_owner_team_path(owner_id: assign.user_id), method: :post, class: 'btn btn-sm btn-success' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,13 +8,16 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles do
         resources :comments
       end
+    end
+    member do
+      post :assign_owner
     end
   end
 


### PR DESCRIPTION
- そのTeamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現し、そのボタンを押すとそのTeamのオーナーが選択したUserに変更される
- Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ
- 情報処理が完了した後はそのTeamのshowに飛ぶ（つまり同じ場所にredirectする）